### PR TITLE
Remove System.out.print that was breaking the csv outputs.

### DIFF
--- a/src/main/java/edu/iris/dmc/station/conditions/EpochRangeCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/EpochRangeCondition.java
@@ -58,8 +58,7 @@ public class EpochRangeCondition extends AbstractCondition {
 
 		if (station.getChannels() != null) {
 			for (Channel c : station.getChannels()) {
-				System.out.println(c.getEndDate());
-				
+
 				if (station.getEndDate() != null && c.getEndDate() == null) {
 					return Result.error("Channel endDate cannot be null"
 						+ " if station endDate is defined as: " + XmlUtil.toText(station.getEndDate()));


### PR DESCRIPTION
This should fix https://github.com/iris-edu/stationxml-validator/issues/86