### PR TITLE
Fix ignored arguments bug

### DIFF
--- a/src/main/java/edu/iris/dmc/Application.java
+++ b/src/main/java/edu/iris/dmc/Application.java
@@ -275,8 +275,8 @@ public class Application {
 		System.out.println("OPTIONS");
 		System.out.println("   --output      	: where to output result, default is System.out");
 		System.out.println("   --ignore-warnings: don't show warnings");
-		System.out.println("   --rules 			: print a list of validation rules");
-		System.out.println("   --units 			: print a list of units used to validate");
+		System.out.println("   --show-rules     : print a list of validation rules");
+		System.out.println("   --show-units     : print a list of units used to validate");
 		System.out.println("   --debug       	:");
 		System.out.println("   --help        	: print this message");
 		System.out.println("===============================================================");

--- a/src/main/java/edu/iris/dmc/CommandLine.java
+++ b/src/main/java/edu/iris/dmc/CommandLine.java
@@ -90,7 +90,7 @@ public class CommandLine {
 		}
 
 		// look for logLevel
-		if (args.length > 2) {
+		if (args.length >= 2) {
 			for (int i = 1; i < args.length; i++) {
 				String arg = args[i];
 				if ("--help".equalsIgnoreCase(arg) || "--showhelp".equalsIgnoreCase(arg)

--- a/src/main/java/edu/iris/dmc/CommandLine.java
+++ b/src/main/java/edu/iris/dmc/CommandLine.java
@@ -75,6 +75,10 @@ public class CommandLine {
 				commandLine.showHelp = true;
 			} else if ("--version".equalsIgnoreCase(args[0]) || "-v".equalsIgnoreCase(args[0])) {
 				commandLine.showVersion = true;
+			} else if ("--show-rules".equalsIgnoreCase(args[0])) {
+				commandLine.showRules = true;
+			} else if ("--show-units".equalsIgnoreCase(args[0])) {
+				commandLine.showUnits = true;
 			}
 			return commandLine;
 		}

--- a/src/main/java/edu/iris/dmc/station/conditions/EpochRangeCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/EpochRangeCondition.java
@@ -58,6 +58,7 @@ public class EpochRangeCondition extends AbstractCondition {
 
 		if (station.getChannels() != null) {
 			for (Channel c : station.getChannels()) {
+
 				if (station.getEndDate() != null && c.getEndDate() == null) {
 					return Result.error("Channel endDate cannot be null"
 						+ " if station endDate is defined as: " + XmlUtil.toText(station.getEndDate()));


### PR DESCRIPTION
Change the arg.length check to not require 3 or more arguments to both parsing args past path.

The check for if (args.length > 2) was making it skip parsing args after the path.