### PR TITLE
#104 - Make easier to use as library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/target/
+.classpath
+.project
+.settings

--- a/src/main/java/edu/iris/dmc/Application.java
+++ b/src/main/java/edu/iris/dmc/Application.java
@@ -87,13 +87,13 @@ public class Application {
 	    		  + " %5$s%6$s %n");
 	      LOGGER = Logger.getLogger(Application.class.getName());
 	  }
-	private static CommandLine commandLine;
 
 	/**
 	 * @param args
 	 * @throws Exception
 	 */
 	public static void main(String[] args) throws Exception {
+		CommandLine commandLine;
 		try {
 			LOGGER.setLevel(Level.WARNING);
 			commandLine = CommandLine.parse(args);
@@ -102,6 +102,7 @@ public class Application {
 			LOGGER.severe(message.toString());
 			help();
 			System.exit(1);
+			return;
 		}
 		LOGGER.setLevel(Level.WARNING);
 		LOGGER.setLevel(commandLine.getLogLevel());
@@ -125,14 +126,24 @@ public class Application {
 		// Add configurable verboisty to this project. 
 		// Update the logger to work similar to converter. 
 		try {
-			Application app = new Application();
+			Application app = new Application(commandLine);
 			app.run();
 		} catch (Exception e) {
-			exitWithError(e);
+			exitWithError(e, commandLine.continueError());
 		}
 	}
 
+	private final CommandLine commandLine;
+
+	public Application(CommandLine commandLine) {
+	    this.commandLine = commandLine;
+	}
+
 	public void run() throws Exception {
+	    run("csv");
+	}
+
+	public void run(String format) throws Exception {
 		Path path = commandLine.input();
 		if (!path.toFile().exists()) {
 			throw new IOException(String.format("File %s does not exist.  File is required!", path.toString()));
@@ -154,21 +165,18 @@ public class Application {
 				//throw new IOException(String.format("File %s is not found!", commandLine.output().toString()));
 			}
 		
-		    try (OutputStream outputStream =  new FileOutputStream(outputFile)) {
-			    run(input, "csv", outputStream, commandLine.ignoreRules(), commandLine.ignoreWarnings());
+			try (OutputStream outputStream =  new FileOutputStream(outputFile)) {
+				run(input, format, outputStream);
 		}
 		}else {
 			try (OutputStream outputStream = System.out;) {
-				run(input, "csv", outputStream, commandLine.ignoreRules(), commandLine.ignoreWarnings());
+				run(input, format, outputStream);
 			}
-			
 		}
-		
 	}
 	
-	private void run(List<Path> input, String format, OutputStream outputStream, int[] ignoreRules,
-			boolean ignoreWarnings) throws Exception {
-		RuleEngineService ruleEngineService = new RuleEngineService(ignoreWarnings, ignoreRules);
+	private void run(List<Path> input, String format, OutputStream outputStream) throws Exception {
+		RuleEngineService ruleEngineService = new RuleEngineService(commandLine.ignoreWarnings(), commandLine.ignoreRules());
 		try (final RuleResultPrintStream ps = getOutputStream(format, outputStream)) {
 			for (Path p : input) {
 				FDSNStationXML document = read(p);
@@ -179,7 +187,7 @@ public class Application {
 				print(ps, ruleEngineService.executeAllRules(document));
 			}
 		} catch (Exception e) {
-			exitWithError(e);
+			error(e);
 			//e.printStackTrace();
 		}
 
@@ -199,7 +207,7 @@ public class Application {
 				try {
 				   return DocumentMarshaller.unmarshal(is);
 				} catch (StationxmlException | IOException | RuntimeException e){
-				    exitWithError(e);
+				    error(e);
 					//StringBuilder message = createExceptionMessage(e);
 					//LOGGER.severe(message.toString());
 					return null;
@@ -211,7 +219,7 @@ public class Application {
 				    Volume volume = IrisUtil.readSeed(file);
 				return SeedToXmlDocumentConverter.getInstance().convert(volume);
 			    }catch(RuntimeException e){
-				    exitWithError(e);
+				    error(e);
 				    //StringBuilder message = createExceptionMessage(e);		
 				    //LOGGER.severe(message.toString());
 				   return null;	
@@ -265,10 +273,13 @@ public class Application {
 		return volume;
 	}
 	
-	
-	private static void exitWithError(Exception e) {
+	protected void error(Exception e) {
+		exitWithError(e, commandLine.continueError());
+	}
+
+	private static void exitWithError(Exception e, boolean continueError) {
 		StringBuilder message = createExceptionMessage(e);
-		if (commandLine.continueError()==true){
+		if (continueError==true){
 			LOGGER.severe(message.toString());
 	        //null 
 		}else {

--- a/src/main/java/edu/iris/dmc/CommandLine.java
+++ b/src/main/java/edu/iris/dmc/CommandLine.java
@@ -33,8 +33,18 @@ public class CommandLine {
 		return input;
 	}
 
+	public CommandLine setInput(Path input)	{
+		this.input = input;
+		return this;
+	}
+
 	public Path output() {
 		return output;
+	}
+
+	public CommandLine setOutput(Path output) {
+		this.output = output;
+		return this;
 	}
 
 	public boolean showHelp() {
@@ -49,31 +59,57 @@ public class CommandLine {
 		return ignoreWarnings;
 	}
 
+	public CommandLine setIgnoreWarnings(boolean b) {
+		this.ignoreWarnings = b;
+		return this;
+	}
+
 	public int[] ignoreRules() {
 		return ignoreRules;
+	}
+
+	public CommandLine setIgnoreRules(int[] rules) {
+		this.ignoreRules = rules;
+		return this;
 	}
 
 	public boolean showRules() {
 		return showRules;
 	}
-	
+
+	public CommandLine setShowRules(boolean b) {
+		this.showRules = b;
+		return this;
+	}
+
 	public boolean continueError() {
 		return continueError;
 	}
-	
+
+	public CommandLine setContinueError(boolean b) {
+		this.continueError = b;
+		return this;
+	}
+
 	public boolean showUnits() {
 		return showUnits;
+	}
+
+	public CommandLine setShowUnits(boolean b) {
+		this.showUnits = b;
+		return this;
 	}
 
 	public Level getLogLevel() {
 		return logLevel;
 	}
+
 	public static CommandLine parse(String[] args) throws CommandLineParseException {
 		CommandLine commandLine = new CommandLine();
 
 		if (args == null || args.length == 0) {
 			throw new CommandLineParseException("Application arguments cannot be empty or null!");
-			
+
 		}
 		// look for showHelp or showVersion flags
 		if (args.length == 1) {
@@ -100,7 +136,7 @@ public class CommandLine {
 
 				}
 			}
-			
+
 		}
 		if (args.length < 1) {
 			throw new CommandLineParseException(
@@ -126,7 +162,7 @@ public class CommandLine {
 					commandLine.ignoreWarnings = true;
 				} else if ("--ignore-rules".equalsIgnoreCase(arg)) {
 					if(args.length < (i+2)) {
-						throw new CommandLineParseException(String.format("Please provide rules to ignore."));	
+						throw new CommandLineParseException(String.format("Please provide rules to ignore."));
 					}else {
 					    String rules = args[i + 1];
 					    commandLine.ignoreRules = Stream.of(rules.split("\\s*,\\s*")).map(String::trim)
@@ -141,14 +177,14 @@ public class CommandLine {
 					commandLine.continueError = true;
 				}  else if ("--output".equalsIgnoreCase(arg) || "-o".equalsIgnoreCase(arg)) {
 					if(args.length < (i+2)) {
-						throw new CommandLineParseException(String.format("Please provide an argument for --output."));	
+						throw new CommandLineParseException(String.format("Please provide an argument for --output."));
 					}else {
 					    commandLine.output = Paths.get(args[i + 1]);
 					i = i + 1;
 					}
 				}else if ("--input".equalsIgnoreCase(arg) || "-i".equalsIgnoreCase(arg)) {
 					if(args.length < (i+2)) {
-						throw new CommandLineParseException(String.format("Please provide an argument for --file."));	
+						throw new CommandLineParseException(String.format("Please provide an argument for --file."));
 					}else {
 					    String path = args[i+1];
 					    commandLine.input = Paths.get(path);

--- a/src/main/java/edu/iris/dmc/CommandLine.java
+++ b/src/main/java/edu/iris/dmc/CommandLine.java
@@ -104,6 +104,11 @@ public class CommandLine {
 		return logLevel;
 	}
 
+	public CommandLine setLogLevel(Level level) {
+		this.logLevel = logLevel;
+		return this;
+	}
+
 	public static CommandLine parse(String[] args) throws CommandLineParseException {
 		CommandLine commandLine = new CommandLine();
 

--- a/src/test/java/edu/iris/dmc/ApplicationTest.java
+++ b/src/test/java/edu/iris/dmc/ApplicationTest.java
@@ -1,0 +1,51 @@
+package edu.iris.dmc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+
+import org.junit.jupiter.api.Test;
+
+public class ApplicationTest {
+
+	@Test
+	public void testPass() throws Exception{
+		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+
+		URL url = ApplicationTest.class.getClassLoader().getResource("pass.xml");
+		assertEquals("file", url.getProtocol());
+		CommandLine commandLine = new CommandLine().setContinueError(true).setLogLevel(Level.INFO).setIgnoreWarnings(true).setInput(new File(url.toURI()).toPath());
+		Application application = new Application(commandLine);
+		application.run("csv", outContent);
+
+		String output = new String(outContent.toByteArray());
+		assertTrue(output.contains("PASSED"));
+	}
+
+	@Test
+	public void testFail() throws Exception{
+		ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+
+		URL url = ApplicationTest.class.getClassLoader().getResource("continueonerror/fail.xml");
+		assertEquals("file", url.getProtocol());
+		CommandLine commandLine = new CommandLine().setContinueError(true).setLogLevel(Level.INFO).setIgnoreWarnings(true).setInput(new File(url.toURI()).toPath());
+		AtomicReference<Exception> ref = new AtomicReference<>();
+		Application application = new Application(commandLine) {
+			@Override
+			protected void error(Exception e) {
+			  ref.set(e);
+			}
+		};
+		application.run("csv", outContent);
+
+		String output = new String(outContent.toByteArray());
+		assertTrue(output.isEmpty());
+		assertTrue(ref.get() != null);
+		assertTrue(ref.get().getMessage().contains("The element type \"Station\" must be terminated by the matching end-tag \"</Station>\""));
+	}
+}


### PR DESCRIPTION
This addresses issue #104 . 

These changes make it easier to use stationxml-validator as a library in other code by:

- Being able to create `CommandLine` "settings" directly in Java without parsing a string[] of args.
- Instantiate the `Application` class itself with these settings and extending the class to handle errors differently.
- Being able to call `run` with different parameters, like an explicit `OutputStream`, rather than just for an output file.

I've tried to maintain coding standards and any existing usage of the class, so there should be little-to-no impact on your continued development (it looks like things might be in a bit of flux eg `format` is not used in `CommandLine`, etc).

# Testing
- All existing tests still pass.
- Added new basic testing of using the Application class as a library.