### PR TITLE
Turn errors into warnings.

### DIFF
--- a/src/main/java/edu/iris/dmc/station/conditions/DistanceCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/DistanceCondition.java
@@ -43,7 +43,7 @@ public class DistanceCondition extends AbstractCondition {
 					channel.getLongitude().getValue(), station.getLatitude().getValue(),
 					station.getLongitude().getValue(), "K");
 			if (distance > this.margin) {
-				nestedMessage.add(Result.error("Distance between Sta: " 
+				nestedMessage.add(Result.warning("Distance between Sta: "
 						+ station.getCode() + " and Chan: " + channel.getCode() + " Loc: " + channel.getLocationCode()
 						+ " is expected to be less than " + margin + " km but is " + distance + " km"));
 				returnmessage=true;

--- a/src/main/java/edu/iris/dmc/station/conditions/SampleRateCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/SampleRateCondition.java
@@ -41,7 +41,7 @@ public class SampleRateCondition extends ChannelRestrictedCondition {
 				if (sampleRate.getValue() != 0) {
 
 				} else {
-					return Result.error("Sample rate cannot be 0 or null.");
+					return Result.warning("Sample rate cannot be 0 or null.");
 				}
 			} else {
 

--- a/src/test/java/edu/iris/dmc/station/conditions/Condition305Test.java
+++ b/src/test/java/edu/iris/dmc/station/conditions/Condition305Test.java
@@ -36,7 +36,7 @@ public class Condition305Test {
 			SampleRateCondition condition = new SampleRateCondition(true, "");
 
 			Message result = condition.evaluate(c);
-			assertTrue(result instanceof edu.iris.dmc.station.rules.Error);
+			assertTrue(result instanceof edu.iris.dmc.station.rules.Warning);
 		}
 
 	}


### PR DESCRIPTION
This branch turns stationxml-validator rules 305 and 222 from error messages into warnings and allows these issues to pass through the statinoxml-validator. 

Merging and deploying this branch will resolve: Issues,  #141,  #143, and  #144.