### PR TITLE
Turns Rule 304 from Erorr into Warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,0 @@
-/target/
-<<<<<<< HEAD
-=======
-.classpath
-.project
-.settings
->>>>>>> branch 'master' of https://github.com/iris-edu/stationxml-validator.git

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<groupId>edu.iris.dmc</groupId>
 	<artifactId>stationxml-validator</artifactId>
 	<packaging>jar</packaging>
-	<version>1.7.4</version>
+	<version>1.7.5</version>
 	<name>FDSN StationXML Validator</name>
     <url>http://maven.apache.org</url>
     <description>Converts seismological metadata between dataless seed and FDSN StationXML file formats.</description>

--- a/src/main/java/edu/iris/dmc/station/conditions/SensorCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/SensorCondition.java
@@ -30,12 +30,12 @@ public class SensorCondition extends AbstractCondition {
 		}
 
 		Equipment equipment = channel.getSensor();
-		if (this.required) {
+        if (this.required) {
 			if (equipment == null) {
-				return Result.error("expected equipment/sensor but was null");
+				return Result.warning("expected equipment/sensor but was null");
 			}else{
 				if (equipment.getDescription() == null||equipment.getDescription().trim().isEmpty()) {
-					return Result.error("expected equipment/sensor description but was null");
+					return Result.warning("expected equipment/sensor description but was null");
 				}
 			}
 		}

--- a/src/test/java/edu/iris/dmc/station/conditions/Condition304Test.java
+++ b/src/test/java/edu/iris/dmc/station/conditions/Condition304Test.java
@@ -36,7 +36,9 @@ public class Condition304Test {
 			SensorCondition condition = new SensorCondition(true, "");
 
 			Message result = condition.evaluate(c);
-			assertTrue(result instanceof edu.iris.dmc.station.rules.Error);
+
+		    System.out.print(result);
+			assertTrue(result instanceof edu.iris.dmc.station.rules.Warning);
 		}
 
 	}

--- a/src/test/java/edu/iris/dmc/station/conditions/SensorCondition304Test.java
+++ b/src/test/java/edu/iris/dmc/station/conditions/SensorCondition304Test.java
@@ -36,7 +36,7 @@ public class SensorCondition304Test {
 			SensorCondition condition = new SensorCondition(true, "");
 
 			Message result = condition.evaluate(c);
-			assertTrue(result instanceof edu.iris.dmc.station.rules.Error);
+			assertTrue(result instanceof edu.iris.dmc.station.rules.Warning);
 		}
 
 	}


### PR DESCRIPTION
This PR turns rule 304: "Channel:Sensor:Description must be included and assigned a string consisting of 1 <= case insensitive A-Z and numeric 0-9 characters." into a warning rather than an error. This rule is too restrictive and is preventing metadata form loading. Furthermore, there are multiple fields in stationxml that can describe instruments and sensor.