### PR TITLE
Add complex conjugate pair validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,18 @@
 			<groupId>edu.iris.dmc</groupId>
 			<artifactId>stationxml-seed-converter</artifactId>
                         <version>2.1.3</version>
+			<exclusions>
+				<exclusion>
+					<groupId>edu.iris.dmc</groupId>
+					<artifactId>java-4-seed</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>edu.iris.dmc</groupId>
+			<artifactId>java-4-seed</artifactId>
+			<version>1.1.0</version>
+			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/edu/iris/dmc/station/RuleEngineRegistry.java
+++ b/src/main/java/edu/iris/dmc/station/RuleEngineRegistry.java
@@ -15,6 +15,7 @@ import edu.iris.dmc.fdsn.station.model.Station;
 import edu.iris.dmc.station.conditions.AzimuthDipCondition;
 import edu.iris.dmc.station.conditions.CalibrationUnitCondition;
 import edu.iris.dmc.station.conditions.CodeCondition;
+import edu.iris.dmc.station.conditions.ComplexConjugateCondition;
 import edu.iris.dmc.station.conditions.Condition;
 import edu.iris.dmc.station.conditions.DecimationAnalogFilterCondition;
 import edu.iris.dmc.station.conditions.DecimationCondition;
@@ -37,7 +38,6 @@ import edu.iris.dmc.station.conditions.OrientationCondition;
 import edu.iris.dmc.station.conditions.OrientationConditionE;
 import edu.iris.dmc.station.conditions.OrientationConditionZ;
 import edu.iris.dmc.station.conditions.PolesZerosCondition;
-import edu.iris.dmc.station.conditions.PolesZerosSequenceCondition;
 import edu.iris.dmc.station.conditions.PolynomialCondition;
 import edu.iris.dmc.station.conditions.ResponseListCondition;
 import edu.iris.dmc.station.conditions.SampleRateCondition;
@@ -276,11 +276,12 @@ public class RuleEngineRegistry {
 					"Response must include InstrumentSensitivity if no Polynomial stages are included.",
 					new ChannelCodeRestriction(), new ChannelTypeRestriction()), Response.class);
 		}
-		//if (!s.contains(417)) {
-		//	add(417, new PolesZerosSequenceCondition(false,
-		//			"If Stage[N]:PolesZeros contains Zeros and Poles then Zero:Number and Pole:Number must start at 0 and be sequential.",
-		//			new ChannelCodeRestriction(), new ChannelTypeRestriction()), Response.class);
-		//}
+		if (!s.contains(417)) {
+			add(417, new ComplexConjugateCondition(false,
+					"If Stage[N] of type PolesZeros contains a Pole or Zero with nonzero Imaginary component then Stage[N]:PolesZeros:Poles or Stage[N]:PolesZeros:Zeros must also include its complex conjugate.",
+					new ChannelCodeRestriction(), new ChannelTypeRestriction(), new ResponsePolynomialRestriction()),
+					Response.class);
+		}
 		
 		if (!s.contains(420)) {
 			add(420, new MissingDecimationCondition(true,

--- a/src/main/java/edu/iris/dmc/station/conditions/ComplexConjugateCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/ComplexConjugateCondition.java
@@ -59,7 +59,7 @@ public class ComplexConjugateCondition extends ChannelRestrictedCondition {
                         // first, collect potential conjugate pairs
                         for (PoleZero z : s.getPolesZeros().getZero()) {
                             double realValue = z.getReal().getValue();
-                            double imaginaryValue = z.getReal().getValue();
+                            double imaginaryValue = z.getImaginary().getValue();
                             if (imaginaryValue == 0.) {
                                 continue;
                             }
@@ -87,7 +87,7 @@ public class ComplexConjugateCondition extends ChannelRestrictedCondition {
                         // first, collect potential conjugate pairs
                         for (PoleZero p : s.getPolesZeros().getPole()) {
                             double realValue = p.getReal().getValue();
-                            double imaginaryValue = p.getReal().getValue();
+                            double imaginaryValue = p.getImaginary().getValue();
                             if (imaginaryValue == 0.) {
                                 continue;
                             }

--- a/src/main/java/edu/iris/dmc/station/conditions/ComplexConjugateCondition.java
+++ b/src/main/java/edu/iris/dmc/station/conditions/ComplexConjugateCondition.java
@@ -1,0 +1,122 @@
+package edu.iris.dmc.station.conditions;
+
+import edu.iris.dmc.fdsn.station.model.*;
+import edu.iris.dmc.station.restrictions.Restriction;
+import edu.iris.dmc.station.rules.Message;
+import edu.iris.dmc.station.rules.Result;
+
+import java.text.DecimalFormat;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+public class ComplexConjugateCondition extends ChannelRestrictedCondition {
+
+    private static final Logger LOGGER = Logger.getLogger(ComplexConjugateCondition.class.getName());
+
+    private final DecimalFormat df = new DecimalFormat("#.#####");
+
+    public ComplexConjugateCondition(boolean required, String description, Restriction... restrictions) {
+        super(required, description, restrictions);
+    }
+
+    @Override
+    public Message evaluate(Network network) {
+        throw new IllegalArgumentException("method not supported!");
+    }
+
+    @Override
+    public Message evaluate(Station station) {
+        throw new IllegalArgumentException("method not supported!");
+    }
+
+    @Override
+    public Message evaluate(Channel channel) {
+        if (channel == null) {
+            return Result.success();
+        }
+        return evaluate(channel, channel.getResponse());
+    }
+
+    @Override
+    public Message evaluate(Channel channel, Response response) {
+
+        if (isRestricted(channel)) {
+            return Result.success();
+        }
+        if (this.required) {
+            if (response == null) {
+                return Result.error("expected response but was null");
+            }
+        }
+        if (response.getStage() != null && !response.getStage().isEmpty()) {
+            List<ResponseStage> stages = response.getStage();
+            int stage = 1;
+            for (ResponseStage s : stages) {
+                if (s.getPolesZeros() != null) {
+                    if (s.getPolesZeros().getZero() != null) {
+                        Map<Double, Set<Double>> conjugatePairMap = new ConcurrentHashMap<>();
+                        // first, collect potential conjugate pairs
+                        for (PoleZero z : s.getPolesZeros().getZero()) {
+                            double realValue = z.getReal().getValue();
+                            double imaginaryValue = z.getReal().getValue();
+                            if (imaginaryValue == 0.) {
+                                continue;
+                            }
+                            if (!conjugatePairMap.containsKey(z.getReal().getValue())) {
+                                conjugatePairMap.put(realValue, new HashSet<>());
+                            }
+                            conjugatePairMap.get(realValue).add(imaginaryValue);
+                        }
+                        // now, check existence of conjugate pairs
+                        for (Double key : conjugatePairMap.keySet()) {
+                            Set<Double> pairs = conjugatePairMap.get(key);
+                            for (Double imaginaryValue : pairs) {
+                                Double conjugate = -1 * imaginaryValue;
+                                if (!pairs.contains(conjugate)){
+                                    // stage 2 zero with real term -2.31400 and nonzero imaginary term -3.17000 has no conjugate pair
+                                    return Result.error("stage " + s.getNumber() + " zero with real term " +
+                                            df.format(key) + " and nonzero imaginary term " +
+                                            df.format(imaginaryValue) + " has no conjugate pair");
+                                }
+                            }
+                        }
+                    }
+                    if (s.getPolesZeros().getPole() != null) {
+                        Map<Double, Set<Double>> conjugatePairMap = new ConcurrentHashMap<>();
+                        // first, collect potential conjugate pairs
+                        for (PoleZero p : s.getPolesZeros().getPole()) {
+                            double realValue = p.getReal().getValue();
+                            double imaginaryValue = p.getReal().getValue();
+                            if (imaginaryValue == 0.) {
+                                continue;
+                            }
+                            if (!conjugatePairMap.containsKey(p.getReal().getValue())) {
+                                conjugatePairMap.put(realValue, new HashSet<>());
+                            }
+                            conjugatePairMap.get(realValue).add(imaginaryValue);
+                        }
+                        // now, check existence of conjugate pairs
+                        for (Double key : conjugatePairMap.keySet()) {
+                            Set<Double> pairs = conjugatePairMap.get(key);
+                            for (Double imaginaryValue : pairs) {
+                                Double conjugate = -1 * imaginaryValue;
+                                if (!pairs.contains(conjugate)){
+                                    // stage 2 pole with real term -2.31400 and nonzero imaginary term -3.17000 has no conjugate pair
+                                    return Result.error("stage " + s.getNumber() + " pole with real term " +
+                                            df.format(key) + " and nonzero imaginary term " +
+                                            df.format(imaginaryValue) + " has no conjugate pair");
+                                }
+                            }
+                        }
+                    }
+                }
+                stage++;
+            }
+
+        }
+
+        return Result.success();
+    }
+
+}

--- a/src/test/java/edu/iris/dmc/station/conditions/Condition417Test.java
+++ b/src/test/java/edu/iris/dmc/station/conditions/Condition417Test.java
@@ -39,7 +39,7 @@ public class Condition417Test {
             Restriction[] restrictions = new Restriction[] { new ChannelCodeRestriction(),
                     new ChannelTypeRestriction() };
 
-            PolesZerosCondition condition = new PolesZerosCondition(true, "", restrictions);
+            ComplexConjugateCondition condition = new ComplexConjugateCondition(true, "", restrictions);
 
             Response response = bhz00.getResponse();
             Message result = condition.evaluate(bhz00, response);
@@ -62,9 +62,10 @@ public class Condition417Test {
             Restriction[] restrictions = new Restriction[] { new ChannelCodeRestriction(),
                     new ChannelTypeRestriction() };
 
-            PolesZerosCondition condition = new PolesZerosCondition(true, "", restrictions);
+            ComplexConjugateCondition condition = new ComplexConjugateCondition(true, "", restrictions);
             Response response = bhz00.getResponse();
             Message result = condition.evaluate(bhz00, response);
+            System.out.println(result);
             Assert.assertTrue(result instanceof Success);
         }
 

--- a/src/test/java/edu/iris/dmc/station/conditions/Condition417Test.java
+++ b/src/test/java/edu/iris/dmc/station/conditions/Condition417Test.java
@@ -1,0 +1,72 @@
+package edu.iris.dmc.station.conditions;
+
+import edu.iris.dmc.DocumentMarshaller;
+import edu.iris.dmc.fdsn.station.model.Channel;
+import edu.iris.dmc.fdsn.station.model.FDSNStationXML;
+import edu.iris.dmc.fdsn.station.model.Network;
+import edu.iris.dmc.fdsn.station.model.Response;
+import edu.iris.dmc.station.RuleEngineServiceTest;
+import edu.iris.dmc.station.restrictions.ChannelCodeRestriction;
+import edu.iris.dmc.station.restrictions.ChannelTypeRestriction;
+import edu.iris.dmc.station.restrictions.Restriction;
+import edu.iris.dmc.station.rules.Message;
+import edu.iris.dmc.station.rules.Success;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class Condition417Test {
+
+    private FDSNStationXML theDocument;
+
+    @Before
+    public void init() throws Exception {
+
+    }
+
+    @Test
+    public void fail() throws Exception {
+        // dummy file with zero value with unmatched imaginary value
+        try (InputStream is = RuleEngineServiceTest.class.getClassLoader().getResourceAsStream("F1_417.xml")) {
+            theDocument = DocumentMarshaller.unmarshal(is);
+
+            Network iu = theDocument.getNetwork().get(0);
+            Channel bhz00 = iu.getStations().get(0).getChannels().get(0);
+
+            Restriction[] restrictions = new Restriction[] { new ChannelCodeRestriction(),
+                    new ChannelTypeRestriction() };
+
+            PolesZerosCondition condition = new PolesZerosCondition(true, "", restrictions);
+
+            Response response = bhz00.getResponse();
+            Message result = condition.evaluate(bhz00, response);
+            Assert.assertTrue(result instanceof edu.iris.dmc.station.rules.Error);
+        }catch(IOException e){
+            e.printStackTrace();
+        }
+
+    }
+
+    @Test
+    public void pass() throws Exception {
+        // this file includes complex conjugate values and should pass examination
+        try (InputStream is = RuleEngineServiceTest.class.getClassLoader().getResourceAsStream("AUMCQBHZ_stageNOSEQUENCE.xml")) {
+            theDocument = DocumentMarshaller.unmarshal(is);
+
+            Network iu = theDocument.getNetwork().get(0);
+            Channel bhz00 = iu.getStations().get(0).getChannels().get(0);
+
+            Restriction[] restrictions = new Restriction[] { new ChannelCodeRestriction(),
+                    new ChannelTypeRestriction() };
+
+            PolesZerosCondition condition = new PolesZerosCondition(true, "", restrictions);
+            Response response = bhz00.getResponse();
+            Message result = condition.evaluate(bhz00, response);
+            Assert.assertTrue(result instanceof Success);
+        }
+
+    }
+}

--- a/src/test/resources/F1_417.xml
+++ b/src/test/resources/F1_417.xml
@@ -25,7 +25,7 @@
     <Longitude>-122.31332</Longitude>
     <Elevation>225.879999</Elevation>
     <Depth>0</Depth>
-    <Azimuth>360</Azimuth>
+    <Azimuth>359</Azimuth>
     <Dip>0</Dip>
     <Type>CONTINUOUS</Type>
     <Type>GEOPHYSICAL</Type>

--- a/src/test/resources/F1_417.xml
+++ b/src/test/resources/F1_417.xml
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+
+<FDSNStationXML xmlns="http://www.fdsn.org/xml/station/1" schemaVersion="1.0" xsi:schemaLocation="http://www.fdsn.org/xml/station/1 http://www.fdsn.org/xml/station/fdsn-station-1.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:iris="http://www.fdsn.org/xml/station/1/iris">
+ <Source>IRIS-DMC</Source>
+ <Sender>IRIS-DMC</Sender>
+ <Module>IRIS WEB SERVICE: fdsnws-station | version: 1.1.33</Module>
+ <ModuleURI>http://service.iris.edu/fdsnws/station/1/query?net=XX&amp;sta=VPASS&amp;cha=BDF&amp;starttime=2018-08-06T00:00:01&amp;level=response&amp;format=xml&amp;includecomments=true&amp;nodata=404</ModuleURI>
+ <Created>2018-08-06T20:17:16</Created>
+ <Network code="XX" startDate="2018-08-06T00:00:00" endDate="2500-12-31T23:59:59" restrictedStatus="open">
+  <Description>[IRIS DMC] Station XML Validator Passing Test File</Description>
+  <TotalNumberStations>1</TotalNumberStations>
+  <SelectedNumberStations>1</SelectedNumberStations>
+  <Station code="TPASS" startDate="2018-08-06T00:00:00" endDate="2500-12-31T23:59:59" restrictedStatus="open" iris:alternateNetworkCodes="_FDSN,.UNRESTRICTED">
+   <Latitude>47.66157</Latitude>
+   <Longitude>-122.31332</Longitude>
+   <Elevation>225.879999</Elevation>
+   <Site>
+    <Name>Synthetic Test File, IRIS DMC, USA, 218 2018, Tim Ronan</Name>
+   </Site>
+   <CreationDate>2018-08-06T00:00:00</CreationDate>
+   <TotalNumberChannels>1</TotalNumberChannels>
+   <SelectedNumberChannels>1</SelectedNumberChannels>
+   <Channel code="BDF" endDate="2500-12-31T23:59:59" locationCode="00" restrictedStatus="open" startDate="2018-08-06T00:00:00">
+    <Latitude>47.66157</Latitude>
+    <Longitude>-122.31332</Longitude>
+    <Elevation>225.879999</Elevation>
+    <Depth>0</Depth>
+    <Azimuth>360</Azimuth>
+    <Dip>0</Dip>
+    <Type>CONTINUOUS</Type>
+    <Type>GEOPHYSICAL</Type>
+    <SampleRate>2E01</SampleRate>
+    <ClockDrift>0E00</ClockDrift>
+    <CalibrationUnits>
+     <Name>V</Name>
+     <Description>Volts</Description>
+    </CalibrationUnits>
+    <Sensor>
+     <Description>Response Developed for testing the station XML validator.</Description>
+    </Sensor>
+    <Response>
+     <InstrumentSensitivity>
+      <Value>10.0</Value>
+      <Frequency>1.0</Frequency>
+      <InputUnits>
+       <Name>PA</Name>
+       <Description>No Abbreviation Referenced</Description>
+      </InputUnits>
+      <OutputUnits>
+       <Name>COUNTS</Name>
+       <Description>Digital Counts</Description>
+      </OutputUnits>
+     </InstrumentSensitivity>
+     <Stage number="1">
+      <PolesZeros>
+       <InputUnits>
+        <Name>PA</Name>
+        <Description>No Abbreviation Referenced</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>V</Name>
+        <Description>Volts</Description>
+       </OutputUnits>
+       <PzTransferFunctionType>LAPLACE (RADIANS/SECOND)</PzTransferFunctionType>
+       <NormalizationFactor>314.1</NormalizationFactor>
+       <NormalizationFrequency>1.00000</NormalizationFrequency>
+       <Zero number="0">
+        <Real minusError="0.00000" plusError="0.00000">0.00000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Zero>
+       <Zero number="1">
+        <Real minusError="0.00000" plusError="0.00000">0.00000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Zero>
+       <Zero number="2">
+        <Real minusError="0.00000" plusError="0.00000">-0.170000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Zero>
+       <Pole number="0">
+        <Real minusError="0.00000" plusError="0.00000">0.00000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Pole>
+       <Pole number="1">
+        <Real minusError="0.00000" plusError="0.00000">-314.000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Pole>
+       <Pole number="2">
+        <Real minusError="0.00000" plusError="0.00000">-0.188000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">0.00000</Imaginary>
+       </Pole>
+       <Pole number="3">
+        <Real minusError="0.00000" plusError="0.00000">-0.0440000</Real>
+        <Imaginary minusError="0.00000" plusError="0.00000">-1.00000</Imaginary>
+       </Pole>
+      </PolesZeros>
+      <StageGain>
+       <Value>5.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="2">
+      <StageGain>
+       <Value>2.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="3">
+      <Coefficients>
+       <InputUnits>
+        <Name>V</Name>
+        <Description>Volts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">1.00000</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>80.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>0.0</Delay>
+       <Correction>0.0</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="4">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0312500</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>40.0</InputSampleRate>
+       <Factor>2</Factor>
+       <Offset>0</Offset>
+       <Delay>3.9063E-5</Delay>
+       <Correction>3.9063E-5</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+     <Stage number="5">
+      <Coefficients>
+       <InputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </InputUnits>
+       <OutputUnits>
+        <Name>COUNTS</Name>
+        <Description>Digital Counts</Description>
+       </OutputUnits>
+       <CfTransferFunctionType>DIGITAL</CfTransferFunctionType>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0156250</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0937500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.234375</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.312500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.234375</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0937500</Numerator>
+       <Numerator minusError="0.00000" plusError="0.00000">0.0156250</Numerator>
+      </Coefficients>
+      <Decimation>
+       <InputSampleRate>20.0</InputSampleRate>
+       <Factor>1</Factor>
+       <Offset>0</Offset>
+       <Delay>9.375E-5</Delay>
+       <Correction>9.375E-5</Correction>
+      </Decimation>
+      <StageGain>
+       <Value>1.0</Value>
+       <Frequency>1.0</Frequency>
+      </StageGain>
+     </Stage>
+    </Response>
+   </Channel>
+  </Station>
+ </Network>
+</FDSNStationXML>


### PR DESCRIPTION
Changes related to https://github.com/iris-edu/stationxml-validator/issues/162

I expect these changes will require further review. Due to issues with dependencies (the master branch requires java-4-seed 1.1.1-SNAPSHOT which is not on Maven) I have not been able to build/run the existing tests, and did not see any CI/automated testing setups for the codebase.

Pseudocode of this rule:

```
IF Stage[N]:PolesZeros is INCLUDED AND Stage[N]:PolesZeros:Zero[N]:Imaginary != 0 THEN Stage[N]:PolesZeros:Zero[M]:Imaginary == -1 * Stage[N]:PolesZeros:Zero[N]:Imaginary AND Stage[N]:PolesZeros:Zero[M]:Real == Stage[N]:PolesZeros:Zero[N]:Real
AND 
IF Stage[N]:PolesZeros is INCLUDED AND Stage[N]:PolesZeros:Pole[N]:Imaginary != 0 THEN Stage[N]:PolesZeros:Pole[M]:Imaginary == -1 * Stage[N]:PolesZeros:Pole[N]:Imaginary AND Stage[N]:PolesZeros:Pole[M]:Real == Stage[N]:PolesZeros:Pole[N]:Real
```